### PR TITLE
Implemented hyperdual space for partials computation, and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Fully-featured Dual Number implementation with features for automatic differenti
 ```rust
 extern crate dual_num;
 
-use dual_num::{DualNumber, Float, differentiate};
+use dual_num::{Dual, Float, differentiate};
 
 fn main() {
     // find partial derivative at x=4.0

--- a/src/differentials.rs
+++ b/src/differentials.rs
@@ -1,4 +1,4 @@
-use super::na::{allocator::Allocator, DefaultAllocator, DimName, MatrixMN, Real, VectorN};
+use super::na::{DefaultAllocator, DimName, MatrixMN, Real, VectorN, allocator::Allocator};
 
 use super::{Dual, Num, One, Scalar};
 
@@ -17,19 +17,13 @@ where
 /// Let `t` be a parameter, `x` be a state vector and `f` be a function whose gradient is seeked.
 /// Calling `partials_t` will return a tuple of ( f(t, x), ∂f(t, x)/∂x ).
 /// If the function `f` is defined as f: Y^{n} → Y^{n}, where Y is a given group,
-/// than `partials` returns the evaluation and gradient of `f` at position `x`, i.e.
+/// than `partials_t` returns the evaluation and gradient of `f` at position `x`, i.e.
 /// a tuple of ( f(t, x), ∇f(t, x) ).
 pub fn partials_t<T: Real + Num, M: DimName, N: DimName, F>(t: T, x: VectorN<T, M>, f: F) -> (VectorN<T, N>, MatrixMN<T, N, M>)
 where
     F: Fn(T, &MatrixMN<Dual<T>, M, M>) -> MatrixMN<Dual<T>, N, M>,
-    DefaultAllocator: Allocator<Dual<T>, M>
-        + Allocator<Dual<T>, M>
-        + Allocator<Dual<T>, N, M>
-        + Allocator<Dual<T>, M, M>
-        + Allocator<usize, N>
-        + Allocator<T, N>
-        + Allocator<T, M>
-        + Allocator<T, N, M>,
+    DefaultAllocator:
+        Allocator<Dual<T>, M> + Allocator<Dual<T>, N, M> + Allocator<Dual<T>, M, M> + Allocator<T, N> + Allocator<T, M> + Allocator<T, N, M>,
 {
     // Create a Matrix for the hyperdual space
     let mut hyperdual_space = MatrixMN::<Dual<T>, M, M>::zeros();
@@ -70,14 +64,8 @@ where
 pub fn partials<T: Real + Num, M: DimName, N: DimName, F>(x: VectorN<T, M>, f: F) -> (VectorN<T, N>, MatrixMN<T, N, M>)
 where
     F: Fn(&MatrixMN<Dual<T>, M, M>) -> MatrixMN<Dual<T>, N, M>,
-    DefaultAllocator: Allocator<Dual<T>, M>
-        + Allocator<Dual<T>, M>
-        + Allocator<Dual<T>, N, M>
-        + Allocator<Dual<T>, M, M>
-        + Allocator<usize, N>
-        + Allocator<T, N>
-        + Allocator<T, M>
-        + Allocator<T, N, M>,
+    DefaultAllocator:
+        Allocator<Dual<T>, M> + Allocator<Dual<T>, N, M> + Allocator<Dual<T>, M, M> + Allocator<T, N> + Allocator<T, M> + Allocator<T, N, M>,
 {
     partials_t(T::zero(), x, |_, x| f(x))
 }

--- a/src/differentials.rs
+++ b/src/differentials.rs
@@ -11,45 +11,52 @@ where
     f(Dual::new(x, T::one())).dual()
 }
 
-/// Computes the gradiant of the provided function with a preliminary time parameter.
+/// Computes the state and the gradiant of the provided function with a preliminary time parameter.
 ///
 /// # How to read this signature:
 /// Let `t` be a parameter, `x` be a state vector and `f` be a function whose gradient is seeked.
-/// Calling `nabla` will return ∇f(t, x).
-pub fn nabla_t<T: Real + Num, N: DimName, F>(t: T, x: VectorN<T, N>, f: F) -> MatrixMN<T, N, N>
+/// Calling `nabla_t` will return a tuple of ( f(t, x), ∇f(t, x) ).
+pub fn nabla_t<T: Real + Num, N: DimName, F>(t: T, x: VectorN<T, N>, f: F) -> (VectorN<T, N>, MatrixMN<T, N, N>)
 where
-    F: Fn(T, &VectorN<Dual<T>, N>) -> VectorN<Dual<T>, N>,
+    F: Fn(T, &MatrixMN<Dual<T>, N, N>) -> MatrixMN<Dual<T>, N, N>,
     DefaultAllocator: Allocator<Dual<T>, N> + Allocator<Dual<T>, N, N> + Allocator<usize, N> + Allocator<T, N> + Allocator<T, N, N>,
 {
-    let mut grad_as_slice = Vec::with_capacity(N::dim() * N::dim());
+    // Create a Matrix for the hyperdual space
+    let mut hyperdual_space = MatrixMN::<Dual<T>, N, N>::zeros();
 
-    // "Simulate" a hyperdual space of size N::dim()
-    for v_i in 0..N::dim() {
-        let mut dual_x = VectorN::<Dual<T>, N>::zeros();
-
-        for i in 0..N::dim() {
-            dual_x[(i, 0)] = Dual::new(x[(i, 0)], if v_i == i { T::one() } else { T::zero() });
+    for i in 0..N::dim() {
+        let mut v_i = VectorN::<Dual<T>, N>::zeros();
+        for j in 0..N::dim() {
+            v_i[(j, 0)] = Dual::new(x[(j, 0)], if i == j { T::one() } else { T::zero() });
         }
-
-        let df_di = f(t, &dual_x);
-
-        for i in 0..N::dim() {
-            grad_as_slice.push(df_di[(i, 0)].dual());
-        }
+        hyperdual_space.set_column(i, &v_i);
     }
 
-    MatrixMN::<T, N, N>::from_column_slice(&grad_as_slice)
+    let state_n_grad = f(t, &hyperdual_space);
+    // Extract the dual part
+    let mut state = VectorN::<T, N>::zeros();
+    let mut grad = MatrixMN::<T, N, N>::zeros();
+    for i in 0..N::dim() {
+        for j in 0..N::dim() {
+            if j == 0 {
+                // The state is duplicated in every column
+                state[(i, j)] = state_n_grad[(i, j)].real();
+            }
+            grad[(i, j)] = state_n_grad[(i, j)].dual();
+        }
+    }
+    (state, grad)
 }
 
-/// Computes the gradiant of the provided function.
+/// Computes the state and gradiant of the provided function.
 ///
 /// # How to read this signature:
 /// Let `x` be a state vector and `f` be a function whose gradient is seeked.
-/// Calling `nabla` will return ∇f(x).
+/// Calling `nabla` will return a tuple of ( f(x), ∇f(x) ).
 #[inline]
-pub fn nabla<T: Real + Num, N: DimName, F>(x: VectorN<T, N>, f: F) -> MatrixMN<T, N, N>
+pub fn nabla<T: Real + Num, N: DimName, F>(x: VectorN<T, N>, f: F) -> (VectorN<T, N>, MatrixMN<T, N, N>)
 where
-    F: Fn(&VectorN<Dual<T>, N>) -> VectorN<Dual<T>, N>,
+    F: Fn(&MatrixMN<Dual<T>, N, N>) -> MatrixMN<Dual<T>, N, N>,
     DefaultAllocator: Allocator<Dual<T>, N> + Allocator<Dual<T>, N, N> + Allocator<usize, N> + Allocator<T, N> + Allocator<T, N, N>,
 {
     nabla_t(T::zero(), x, |_, x| f(x))

--- a/src/differentials.rs
+++ b/src/differentials.rs
@@ -1,6 +1,6 @@
-use super::na::{DefaultAllocator, DimName, MatrixMN, Real, VectorN, allocator::Allocator};
+use na::{allocator::Allocator, DefaultAllocator, DimName, MatrixMN, Real, VectorN};
 
-use super::{Dual, Num, One, Scalar};
+use {Dual, Num, One, Scalar};
 
 /// Evaluates the function using dual numbers to get the partial derivative at the input point
 #[inline]
@@ -30,25 +30,31 @@ where
 
     for i in 0..M::dim() {
         let mut v_i = VectorN::<Dual<T>, M>::zeros();
+
         for j in 0..M::dim() {
             v_i[(j, 0)] = Dual::new(x[(j, 0)], if i == j { T::one() } else { T::zero() });
         }
+
         hyperdual_space.set_column(i, &v_i);
     }
 
     let state_n_grad = f(t, &hyperdual_space);
+
     // Extract the dual part
     let mut state = VectorN::<T, N>::zeros();
     let mut grad = MatrixMN::<T, N, M>::zeros();
+
     for i in 0..N::dim() {
         for j in 0..M::dim() {
             if j == 0 {
                 // The state is duplicated in every column
                 state[(i, 0)] = state_n_grad[(i, 0)].real();
             }
+
             grad[(i, j)] = state_n_grad[(i, j)].dual();
         }
     }
+
     (state, grad)
 }
 

--- a/src/differentials.rs
+++ b/src/differentials.rs
@@ -19,7 +19,7 @@ where
 /// If the function `f` is defined as f: Y^{n} → Y^{n}, where Y is a given group,
 /// than `partials` returns the evaluation and gradient of `f` at position `x`, i.e.
 /// a tuple of ( f(t, x), ∇f(t, x) ).
-pub fn partials_t<T: Real + Num, M: DimName, N: DimName, F>(t: T, x: VectorN<T, M>, f: F) -> (VectorN<T, M>, MatrixMN<T, N, M>)
+pub fn partials_t<T: Real + Num, M: DimName, N: DimName, F>(t: T, x: VectorN<T, M>, f: F) -> (VectorN<T, N>, MatrixMN<T, N, M>)
 where
     F: Fn(T, &MatrixMN<Dual<T>, M, M>) -> MatrixMN<Dual<T>, N, M>,
     DefaultAllocator: Allocator<Dual<T>, M>
@@ -44,13 +44,13 @@ where
 
     let state_n_grad = f(t, &hyperdual_space);
     // Extract the dual part
-    let mut state = VectorN::<T, M>::zeros();
+    let mut state = VectorN::<T, N>::zeros();
     let mut grad = MatrixMN::<T, N, M>::zeros();
-    for i in 0..M::dim() {
-        for j in 0..N::dim() {
+    for i in 0..N::dim() {
+        for j in 0..M::dim() {
             if j == 0 {
                 // The state is duplicated in every column
-                state[(i, j)] = state_n_grad[(i, j)].real();
+                state[(i, 0)] = state_n_grad[(i, 0)].real();
             }
             grad[(i, j)] = state_n_grad[(i, j)].dual();
         }
@@ -67,7 +67,7 @@ where
 /// than `partials` returns the evaluation and gradient of `f` at position `x`, i.e.
 /// a tuple of ( f(x), ∇f(x) ).
 #[inline]
-pub fn partials<T: Real + Num, M: DimName, N: DimName, F>(x: VectorN<T, M>, f: F) -> (VectorN<T, M>, MatrixMN<T, N, M>)
+pub fn partials<T: Real + Num, M: DimName, N: DimName, F>(x: VectorN<T, M>, f: F) -> (VectorN<T, N>, MatrixMN<T, N, M>)
 where
     F: Fn(&MatrixMN<Dual<T>, M, M>) -> MatrixMN<Dual<T>, N, M>,
     DefaultAllocator: Allocator<Dual<T>, M>

--- a/src/differentials.rs
+++ b/src/differentials.rs
@@ -11,22 +11,32 @@ where
     f(Dual::new(x, T::one())).dual()
 }
 
-/// Computes the state and the gradiant of the provided function with a preliminary time parameter.
+/// Computes the state and the partials matrix of the provided function with a preliminary time parameter.
 ///
 /// # How to read this signature:
 /// Let `t` be a parameter, `x` be a state vector and `f` be a function whose gradient is seeked.
-/// Calling `nabla_t` will return a tuple of ( f(t, x), ∇f(t, x) ).
-pub fn nabla_t<T: Real + Num, N: DimName, F>(t: T, x: VectorN<T, N>, f: F) -> (VectorN<T, N>, MatrixMN<T, N, N>)
+/// Calling `partials_t` will return a tuple of ( f(t, x), ∂f(t, x)/∂x ).
+/// If the function `f` is defined as f: Y^{n} → Y^{n}, where Y is a given group,
+/// than `partials` returns the evaluation and gradient of `f` at position `x`, i.e.
+/// a tuple of ( f(t, x), ∇f(t, x) ).
+pub fn partials_t<T: Real + Num, M: DimName, N: DimName, F>(t: T, x: VectorN<T, M>, f: F) -> (VectorN<T, M>, MatrixMN<T, N, M>)
 where
-    F: Fn(T, &MatrixMN<Dual<T>, N, N>) -> MatrixMN<Dual<T>, N, N>,
-    DefaultAllocator: Allocator<Dual<T>, N> + Allocator<Dual<T>, N, N> + Allocator<usize, N> + Allocator<T, N> + Allocator<T, N, N>,
+    F: Fn(T, &MatrixMN<Dual<T>, M, M>) -> MatrixMN<Dual<T>, N, M>,
+    DefaultAllocator: Allocator<Dual<T>, M>
+        + Allocator<Dual<T>, M>
+        + Allocator<Dual<T>, N, M>
+        + Allocator<Dual<T>, M, M>
+        + Allocator<usize, N>
+        + Allocator<T, N>
+        + Allocator<T, M>
+        + Allocator<T, N, M>,
 {
     // Create a Matrix for the hyperdual space
-    let mut hyperdual_space = MatrixMN::<Dual<T>, N, N>::zeros();
+    let mut hyperdual_space = MatrixMN::<Dual<T>, M, M>::zeros();
 
-    for i in 0..N::dim() {
-        let mut v_i = VectorN::<Dual<T>, N>::zeros();
-        for j in 0..N::dim() {
+    for i in 0..M::dim() {
+        let mut v_i = VectorN::<Dual<T>, M>::zeros();
+        for j in 0..M::dim() {
             v_i[(j, 0)] = Dual::new(x[(j, 0)], if i == j { T::one() } else { T::zero() });
         }
         hyperdual_space.set_column(i, &v_i);
@@ -34,9 +44,9 @@ where
 
     let state_n_grad = f(t, &hyperdual_space);
     // Extract the dual part
-    let mut state = VectorN::<T, N>::zeros();
-    let mut grad = MatrixMN::<T, N, N>::zeros();
-    for i in 0..N::dim() {
+    let mut state = VectorN::<T, M>::zeros();
+    let mut grad = MatrixMN::<T, N, M>::zeros();
+    for i in 0..M::dim() {
         for j in 0..N::dim() {
             if j == 0 {
                 // The state is duplicated in every column
@@ -48,16 +58,26 @@ where
     (state, grad)
 }
 
-/// Computes the state and gradiant of the provided function.
+/// Computes the state and partials of the provided function.
 ///
 /// # How to read this signature:
 /// Let `x` be a state vector and `f` be a function whose gradient is seeked.
-/// Calling `nabla` will return a tuple of ( f(x), ∇f(x) ).
+/// Calling `partials` will return a tuple of ( f(x), ∂f(x)/∂x ).
+/// If the function `f` is defined as f: Y^{n} → Y^{n}, where Y is a given group,
+/// than `partials` returns the evaluation and gradient of `f` at position `x`, i.e.
+/// a tuple of ( f(x), ∇f(x) ).
 #[inline]
-pub fn nabla<T: Real + Num, N: DimName, F>(x: VectorN<T, N>, f: F) -> (VectorN<T, N>, MatrixMN<T, N, N>)
+pub fn partials<T: Real + Num, M: DimName, N: DimName, F>(x: VectorN<T, M>, f: F) -> (VectorN<T, M>, MatrixMN<T, N, M>)
 where
-    F: Fn(&MatrixMN<Dual<T>, N, N>) -> MatrixMN<Dual<T>, N, N>,
-    DefaultAllocator: Allocator<Dual<T>, N> + Allocator<Dual<T>, N, N> + Allocator<usize, N> + Allocator<T, N> + Allocator<T, N, N>,
+    F: Fn(&MatrixMN<Dual<T>, M, M>) -> MatrixMN<Dual<T>, N, M>,
+    DefaultAllocator: Allocator<Dual<T>, M>
+        + Allocator<Dual<T>, M>
+        + Allocator<Dual<T>, N, M>
+        + Allocator<Dual<T>, M, M>
+        + Allocator<usize, N>
+        + Allocator<T, N>
+        + Allocator<T, M>
+        + Allocator<T, N, M>,
 {
-    nabla_t(T::zero(), x, |_, x| f(x))
+    partials_t(T::zero(), x, |_, x| f(x))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,6 @@
 //! Dual Numbers
 //!
-//! This is a dual number implementation scavenged from other dual number libraries and articles around the web, including:
-//!
-//! * [https://github.com/FreeFull/dual_numbers](https://github.com/FreeFull/dual_numbers)
-//! * [https://github.com/ibab/rust-ad](https://github.com/ibab/rust-ad)
-//! * [https://github.com/tesch1/cxxduals](https://github.com/tesch1/cxxduals)
-//!
-//! The difference being is that I have checked each method against Wolfram Alpha for correctness and will
-//! keep this implementation up to date and working with the latest stable Rust and `num-traits` crate.
+//! Fully-featured Dual Number implementation with features for automatic differentiation of multivariate vectorial functions into gradients.
 //!
 //! ## Usage
 //!
@@ -23,6 +16,11 @@
 //!     })); // 0.25000
 //! }
 //! ```
+//!
+//! ##### Previous Work
+//! * [https://github.com/FreeFull/dual_numbers](https://github.com/FreeFull/dual_numbers)
+//! * [https://github.com/ibab/rust-ad](https://github.com/ibab/rust-ad)
+//! * [https://github.com/tesch1/cxxduals](https://github.com/tesch1/cxxduals)
 
 extern crate nalgebra as na;
 extern crate num_traits;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ extern crate num_traits;
 use std::cmp::Ordering;
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use std::num::FpCategory;
-use std::ops::{Add, Deref, DerefMut, Div, Mul, Neg, Rem, Sub};
+use std::ops::{Add, AddAssign, Deref, DerefMut, Div, DivAssign, Mul, MulAssign, Neg, Rem, Sub, SubAssign};
 
 pub use num_traits::{Float, FloatConst, Num, One, Zero};
 
@@ -241,11 +241,23 @@ impl<T: Scalar + Num> Add<T> for Dual<T> {
     }
 }
 
+impl<T: Scalar + Num> AddAssign<T> for Dual<T> {
+    fn add_assign(&mut self, rhs: T) {
+        *self = (*self) + Dual::from_real(rhs)
+    }
+}
+
 impl<T: Scalar + Num> Sub<T> for Dual<T> {
     type Output = Dual<T>;
 
     fn sub(self, rhs: T) -> Dual<T> {
         Dual::new(self.real() - rhs, self.dual())
+    }
+}
+
+impl<T: Scalar + Num> SubAssign<T> for Dual<T> {
+    fn sub_assign(&mut self, rhs: T) {
+        *self = (*self) - Dual::from_real(rhs)
     }
 }
 
@@ -257,11 +269,23 @@ impl<T: Scalar + Num> Mul<T> for Dual<T> {
     }
 }
 
+impl<T: Scalar + Num> MulAssign<T> for Dual<T> {
+    fn mul_assign(&mut self, rhs: T) {
+        *self = (*self) * Dual::from_real(rhs)
+    }
+}
+
 impl<T: Scalar + Num> Div<T> for Dual<T> {
     type Output = Dual<T>;
 
     fn div(self, rhs: T) -> Dual<T> {
         self / Dual::from_real(rhs)
+    }
+}
+
+impl<T: Scalar + Num> DivAssign<T> for Dual<T> {
+    fn div_assign(&mut self, rhs: T) {
+        *self = (*self) / Dual::from_real(rhs)
     }
 }
 
@@ -281,6 +305,12 @@ impl<T: Scalar + Num> Add<Self> for Dual<T> {
     }
 }
 
+impl<T: Scalar + Num> AddAssign<Self> for Dual<T> {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = (*self) + rhs
+    }
+}
+
 impl<T: Scalar + Num> Sub<Self> for Dual<T> {
     type Output = Self;
 
@@ -289,11 +319,23 @@ impl<T: Scalar + Num> Sub<Self> for Dual<T> {
     }
 }
 
+impl<T: Scalar + Num> SubAssign<Self> for Dual<T> {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = (*self) - rhs
+    }
+}
+
 impl<T: Scalar + Num> Mul<Self> for Dual<T> {
     type Output = Self;
 
     fn mul(self, rhs: Self) -> Self {
         Dual::new(self.real() * rhs.real(), self.real() * rhs.dual() + self.dual() * rhs.real())
+    }
+}
+
+impl<T: Scalar + Num> MulAssign<Self> for Dual<T> {
+    fn mul_assign(&mut self, rhs: Self) {
+        *self = (*self) * rhs
     }
 }
 
@@ -332,6 +374,12 @@ impl<T: Scalar + Num> Div<Self> for Dual<T> {
             self.real() / rhs.real(),
             (self.dual() * rhs.real() - self.real() * rhs.dual()) / (rhs.real() * rhs.real()),
         )
+    }
+}
+
+impl<T: Scalar + Num> DivAssign<Self> for Dual<T> {
+    fn div_assign(&mut self, rhs: Self) {
+        *self = (*self) / rhs
     }
 }
 

--- a/src/linalg.rs
+++ b/src/linalg.rs
@@ -1,7 +1,7 @@
-use super::na::allocator::Allocator;
-use super::na::{DefaultAllocator, DimName, MatrixMN, Scalar};
+use na::allocator::Allocator;
+use na::{DefaultAllocator, DimName, MatrixMN, Scalar};
 
-use super::{Dual, Float, Zero};
+use {Dual, Float, Zero};
 
 pub fn norm<T: Scalar + Float, M: DimName, N: DimName>(v: &MatrixMN<Dual<T>, M, N>) -> Dual<T>
 where

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -4,8 +4,8 @@ use dual_num::{differentiate, Dual, Float, FloatConst};
 extern crate nalgebra as na;
 
 use dual_num::linalg::norm;
-use dual_num::{nabla, nabla_t};
-use na::{Matrix3x6, Matrix6, U3, U6, Vector3, Vector6};
+use dual_num::{partials, partials_t};
+use na::{Matrix2x6, Matrix3x6, Matrix6, Matrix6x2, U3, U6, Vector3, Vector6};
 
 macro_rules! abs_within {
     ($x:expr, $val:expr, $eps:expr, $msg:expr) => {
@@ -56,7 +56,7 @@ fn test_norm() {
 }
 
 #[test]
-fn gradient_no_param() {
+fn square_gradient_no_param() {
     // This is an example of the equation of motion gradient for a spacecrate in a two body acceleration.
     fn eom(state: &Matrix6<Dual<f64>>) -> Matrix6<Dual<f64>> {
         let radius = state.fixed_slice::<U3, U6>(0, 0).into_owned();
@@ -91,7 +91,7 @@ fn gradient_no_param() {
         -2.226285193102822,
         1.6467383807226765,
     );
-    let (fx, grad) = nabla(state, eom);
+    let (fx, grad) = partials(state, eom);
 
     let expected_fx = Vector6::new(
         -3.28878900377057,
@@ -122,7 +122,7 @@ fn gradient_no_param() {
 }
 
 #[test]
-fn gradient_with_param() {
+fn square_gradient_with_param() {
     // This is an example of the equation of motion gradient for a spacecrate in a two body acceleration.
     fn eom(_t: f64, state: &Matrix6<Dual<f64>>) -> Matrix6<Dual<f64>> {
         let radius = state.fixed_slice::<U3, U6>(0, 0).into_owned();
@@ -158,7 +158,7 @@ fn gradient_with_param() {
         1.6467383807226765,
     );
 
-    let (fx, grad) = nabla_t(0.0, state, eom);
+    let (fx, grad) = partials_t(0.0, state, eom);
 
     let expected_fx = Vector6::new(
         -3.28878900377057,
@@ -188,3 +188,59 @@ fn gradient_with_param() {
 
     zero_within!((grad - expected).norm(), 1e-16, "gradient computation is incorrect");
 }
+/*
+#[test]
+fn nonsquare_gradient_no_param() {
+    // This is an example of the equation of motion gradient for a spacecrate in a two body acceleration.
+    fn sensitivity(state: &Matrix2x6<Dual<f64>>) -> Matrix2x6<Dual<f64>> {
+        panic!("{}", state);
+        let radius = state.fixed_slice::<U3, U6>(0, 0).into_owned();
+        let velocity = state.fixed_slice::<U3, U6>(3, 0).into_owned();
+        let mut body_acceleration = Matrix3x6::zeros();
+        for i in 0..3 {
+            let this_norm = norm(&Vector3::new(radius[(0, i)], radius[(1, i)], radius[(2, i)]));
+            let body_acceleration_f = Dual::from_real(-398_600.4415) / this_norm.powi(3);
+            let this_body_acceleration = Vector3::new(
+                radius[(0, i)] * body_acceleration_f,
+                radius[(1, i)] * body_acceleration_f,
+                radius[(2, i)] * body_acceleration_f,
+            );
+            body_acceleration.set_column(i, &this_body_acceleration);
+        }
+        let mut rtn = Matrix2x6::zeros();
+        // for i in 0..6 {
+        //     if i < 3 {
+        //         rtn.set_row(i, &velocity.row(i));
+        //     } else {
+        //         rtn.set_row(i, &body_acceleration.row(i - 3));
+        //     }
+        // }
+        rtn
+    }
+
+    let rx = Vector6::new(9203.993716, 18450.606914, 7016.410940, -3.769098, 1.255100, 1.644035);
+    let tx = Vector6::new(4849.340233, 360.415547, 4114.752758, -0.026282, 0.353619, 0.000000);
+
+    let (_, grad) = partials(rx - tx, sensitivity);
+
+    /*
+┌                                                                                                                                                 ┐
+│     0.23123905265689662      0.9606180445702461        0.15408268225981                       0                       0                       0 │
+│ -0.00019563292172470923 0.000060817042613472664  0.00008937755133596409     0.23123905265689662      0.9606180445702461        0.15408268225981 │
+└                                                                                                                                                 ┘
+*/
+
+    let mut expected_grad = Matrix2x6::zeros();
+    expected_grad[(0, 0)] = 0.23123905265689662;
+    expected_grad[(0, 1)] = 0.9606180445702461;
+    expected_grad[(0, 2)] = 0.15408268225981;
+    expected_grad[(1, 3)] = -0.00019563292172470923;
+    expected_grad[(1, 4)] = 0.000060817042613472664;
+    expected_grad[(1, 5)] = 0.00008937755133596409;
+    expected_grad[(1, 3)] = 0.23123905265689662;
+    expected_grad[(1, 4)] = 0.9606180445702461;
+    expected_grad[(1, 5)] = 0.15408268225981;
+
+    zero_within!((grad - expected_grad).norm(), 1e-16, "gradient computation is incorrect");
+}
+*/

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -48,6 +48,58 @@ fn derive() {
 }
 
 #[test]
+fn type_operations() {
+    let mut x = Dual::new(1.0, 2.0);
+    let val = 3.0f64;
+    abs_within!((x + val).real(), 4.0, std::f64::EPSILON, "add failed on real part");
+    abs_within!((x + val).dual(), 2.0, std::f64::EPSILON, "add failed on dual part");
+    x += val;
+    abs_within!(x.real(), 4.0, std::f64::EPSILON, "add_assign failed on real part");
+    abs_within!(x.dual(), 2.0, std::f64::EPSILON, "add_assign failed on dual part");
+    abs_within!((x - val).real(), 1.0, std::f64::EPSILON, "sub failed on real part");
+    abs_within!((x - val).dual(), 2.0, std::f64::EPSILON, "sub failed on dual part");
+    x -= val;
+    abs_within!(x.real(), 1.0, std::f64::EPSILON, "sub_assign failed on real part");
+    abs_within!(x.dual(), 2.0, std::f64::EPSILON, "sub_assign failed on dual part");
+    abs_within!((x * val).real(), 3.0, std::f64::EPSILON, "mul failed on real part");
+    abs_within!((x * val).dual(), 6.0, std::f64::EPSILON, "mul failed on dual part");
+    x *= val;
+    abs_within!(x.real(), 3.0, std::f64::EPSILON, "mul_assign failed on real part");
+    abs_within!(x.dual(), 6.0, std::f64::EPSILON, "mul_assign failed on dual part");
+    abs_within!((x / val).real(), 1.0, std::f64::EPSILON, "div failed on real part");
+    abs_within!((x / val).dual(), 2.0, std::f64::EPSILON, "div failed on dual part");
+    x /= val;
+    abs_within!(x.real(), 1.0, std::f64::EPSILON, "div_assign failed on real part");
+    abs_within!(x.dual(), 2.0, std::f64::EPSILON, "div_assign failed on dual part");
+}
+
+#[test]
+fn dual_operations() {
+    let mut x = Dual::new(1.0, 2.0);
+    let y = Dual::new(3.0, 4.0);
+    abs_within!((x + y).real(), 4.0, std::f64::EPSILON, "add failed");
+    abs_within!((x + y).dual(), 6.0, std::f64::EPSILON, "add failed");
+    x += y;
+    abs_within!(x.real(), 4.0, std::f64::EPSILON, "add_assign failed");
+    abs_within!(x.dual(), 6.0, std::f64::EPSILON, "add_assign failed");
+    abs_within!((x - y).real(), 1.0, std::f64::EPSILON, "sub failed");
+    abs_within!((x - y).dual(), 2.0, std::f64::EPSILON, "sub failed");
+    x -= y;
+    abs_within!(x.real(), 1.0, std::f64::EPSILON, "sub_assign failed");
+    abs_within!(x.dual(), 2.0, std::f64::EPSILON, "sub_assign failed");
+    abs_within!((x * y).real(), 3.0, std::f64::EPSILON, "mul failed");
+    abs_within!((x * y).dual(), 10.0, std::f64::EPSILON, "mul failed");
+    x *= y;
+    abs_within!(x.real(), 3.0, std::f64::EPSILON, "mul_assign failed");
+    abs_within!(x.dual(), 10.0, std::f64::EPSILON, "mul_assign failed");
+    abs_within!((x / y).real(), 1.0, std::f64::EPSILON, "div failed");
+    abs_within!((x / y).dual(), 2.0, std::f64::EPSILON, "div failed");
+    x /= y;
+    abs_within!(x.real(), 1.0, std::f64::EPSILON, "div_assign failed");
+    abs_within!(x.dual(), 2.0, std::f64::EPSILON, "div_assign failed");
+}
+
+#[test]
 fn test_norm() {
     let vec = Vector3::new(Dual::from_real(1.0), Dual::from_real(1.0), Dual::from_real(1.0));
     let this_norm = norm(&vec);
@@ -203,6 +255,14 @@ fn nonsquare_gradient_no_param() {
             let mut range_rate = Dual::from(0f64);
             for i in 0..3 {
                 range_rate = range_rate + range_mat[(i, j)] * velocity_mat[(i, j)] / range;
+                println!(
+                    "range_mat[({0}, {1})] ({2}) * velocity_mat[({0}, {1})] {3} = {4}",
+                    i,
+                    j,
+                    range_mat[(i, j)],
+                    velocity_mat[(i, j)],
+                    range_mat[(i, j)] * velocity_mat[(i, j)]
+                );
             }
             range_rate_slice.push(range_rate);
         }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -279,12 +279,9 @@ fn partials_no_param() {
             let rho_vec = Vector3::new(range_mat[(0, j)], range_mat[(1, j)], range_mat[(2, j)]);
             let range = norm(&rho_vec);
             let delta_v_vec = (Vector3::new(velocity_mat[(0, j)], velocity_mat[(1, j)], velocity_mat[(2, j)])) / range;
-
             let rho_dot = rho_vec.dot(&delta_v_vec);
 
             range_slice.push(range);
-
-            println!("{} => {:.30}", j, rho_dot.dual());
             range_rate_slice.push(rho_dot);
         }
         let mut rtn = Matrix2x6::zeros();
@@ -312,21 +309,19 @@ fn partials_no_param() {
     );
 
     let mut expected_dfdx = Matrix2x6::zeros();
-    expected_dfdx[(0, 0)] = 0.231239052656896620918658413757;
-    expected_dfdx[(0, 1)] = 0.960618044570246132352053791692;
-    expected_dfdx[(0, 2)] = 0.154082682259810005431788226815;
-    expected_dfdx[(1, 0)] = -0.000195632921724709225560004389;
-    expected_dfdx[(1, 1)] = 0.000060817042613472663975266591;
-    expected_dfdx[(1, 2)] = 0.000089377551335964087564182889;
-    expected_dfdx[(1, 3)] = 0.231239052656896620918658413757;
-    expected_dfdx[(1, 4)] = 0.960618044570246132352053791692;
-    expected_dfdx[(1, 5)] = 0.154082682259810005431788226815;
-
-    println!("{}{}", dfdx, expected_dfdx);
+    expected_dfdx[(0, 0)] = 0.23123905265689662091;
+    expected_dfdx[(0, 1)] = 0.96061804457024613235;
+    expected_dfdx[(0, 2)] = 0.15408268225981000543;
+    expected_dfdx[(1, 0)] = -0.00020186608829958833;
+    expected_dfdx[(1, 1)] = 0.00003492309339579752;
+    expected_dfdx[(1, 2)] = 0.00008522417406774546;
+    expected_dfdx[(1, 3)] = 0.23123905265689662091;
+    expected_dfdx[(1, 4)] = 0.96061804457024613235;
+    expected_dfdx[(1, 5)] = 0.15408268225981000543;
 
     zero_within!(
         (dfdx - expected_dfdx).norm(),
-        1e-16,
+        1e-20,
         format!("partial computation is incorrect -- here comes the delta: {}", dfdx - expected_dfdx)
     );
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -5,7 +5,7 @@ extern crate nalgebra as na;
 
 use dual_num::linalg::norm;
 use dual_num::{nabla, nabla_t};
-use na::{Matrix6, U3, Vector3, Vector6};
+use na::{Matrix3x6, Matrix6, U3, U6, Vector3, Vector6};
 
 macro_rules! abs_within {
     ($x:expr, $val:expr, $eps:expr, $msg:expr) => {
@@ -58,17 +58,29 @@ fn test_norm() {
 #[test]
 fn gradient_no_param() {
     // This is an example of the equation of motion gradient for a spacecrate in a two body acceleration.
-    fn eom(state: &Vector6<Dual<f64>>) -> Vector6<Dual<f64>> {
-        let radius = state.fixed_rows::<U3>(0).into_owned();
-        let velocity = state.fixed_rows::<U3>(3).into_owned();
-        let norm = (radius[(0, 0)].powi(2) + radius[(1, 0)].powi(2) + radius[(2, 0)].powi(2)).sqrt();
-        let body_acceleration_f = Dual::from_real(-398_600.4415) / norm.powi(3);
-        let body_acceleration = Vector3::new(
-            radius[(0, 0)] * body_acceleration_f,
-            radius[(1, 0)] * body_acceleration_f,
-            radius[(2, 0)] * body_acceleration_f,
-        );
-        Vector6::from_iterator(velocity.iter().chain(body_acceleration.iter()).cloned())
+    fn eom(state: &Matrix6<Dual<f64>>) -> Matrix6<Dual<f64>> {
+        let radius = state.fixed_slice::<U3, U6>(0, 0).into_owned();
+        let velocity = state.fixed_slice::<U3, U6>(3, 0).into_owned();
+        let mut body_acceleration = Matrix3x6::zeros();
+        for i in 0..3 {
+            let this_norm = norm(&Vector3::new(radius[(0, i)], radius[(1, i)], radius[(2, i)]));
+            let body_acceleration_f = Dual::from_real(-398_600.4415) / this_norm.powi(3);
+            let this_body_acceleration = Vector3::new(
+                radius[(0, i)] * body_acceleration_f,
+                radius[(1, i)] * body_acceleration_f,
+                radius[(2, i)] * body_acceleration_f,
+            );
+            body_acceleration.set_column(i, &this_body_acceleration);
+        }
+        let mut rtn = Matrix6::zeros();
+        for i in 0..6 {
+            if i < 3 {
+                rtn.set_row(i, &velocity.row(i));
+            } else {
+                rtn.set_row(i, &body_acceleration.row(i - 3));
+            }
+        }
+        rtn
     }
 
     let state = Vector6::new(
@@ -79,7 +91,18 @@ fn gradient_no_param() {
         -2.226285193102822,
         1.6467383807226765,
     );
-    let grad = nabla(state, eom);
+    let (fx, grad) = nabla(state, eom);
+
+    let expected_fx = Vector6::new(
+        -3.28878900377057,
+        -2.226285193102822,
+        1.6467383807226765,
+        0.0003488751720191492,
+        -0.0007151349009902908,
+        -0.00027005954128877916,
+    );
+
+    zero_within!((fx - expected_fx).norm(), 1e-16, "f(x) computation is incorrect");
 
     let mut expected = Matrix6::zeros();
     expected[(0, 3)] = 1.0;
@@ -101,18 +124,29 @@ fn gradient_no_param() {
 #[test]
 fn gradient_with_param() {
     // This is an example of the equation of motion gradient for a spacecrate in a two body acceleration.
-    fn eom(_t: f64, state: &Vector6<Dual<f64>>) -> Vector6<Dual<f64>> {
-        let radius = state.fixed_rows::<U3>(0).into_owned();
-        let velocity = state.fixed_rows::<U3>(3).into_owned();
-        let norm = (radius[(0, 0)].powi(2) + radius[(1, 0)].powi(2) + radius[(2, 0)].powi(2)).sqrt();
-        let body_acceleration_f = Dual::from_real(-398_600.4415) / norm.powi(3);
-        let body_acceleration = Vector3::new(
-            radius[(0, 0)] * body_acceleration_f,
-            radius[(1, 0)] * body_acceleration_f,
-            radius[(2, 0)] * body_acceleration_f,
-        );
-
-        Vector6::from_iterator(velocity.iter().chain(body_acceleration.iter()).cloned())
+    fn eom(_t: f64, state: &Matrix6<Dual<f64>>) -> Matrix6<Dual<f64>> {
+        let radius = state.fixed_slice::<U3, U6>(0, 0).into_owned();
+        let velocity = state.fixed_slice::<U3, U6>(3, 0).into_owned();
+        let mut body_acceleration = Matrix3x6::zeros();
+        for i in 0..3 {
+            let this_norm = norm(&Vector3::new(radius[(0, i)], radius[(1, i)], radius[(2, i)]));
+            let body_acceleration_f = Dual::from_real(-398_600.4415) / this_norm.powi(3);
+            let this_body_acceleration = Vector3::new(
+                radius[(0, i)] * body_acceleration_f,
+                radius[(1, i)] * body_acceleration_f,
+                radius[(2, i)] * body_acceleration_f,
+            );
+            body_acceleration.set_column(i, &this_body_acceleration);
+        }
+        let mut rtn = Matrix6::zeros();
+        for i in 0..6 {
+            if i < 3 {
+                rtn.set_row(i, &velocity.row(i));
+            } else {
+                rtn.set_row(i, &body_acceleration.row(i - 3));
+            }
+        }
+        rtn
     }
 
     let state = Vector6::new(
@@ -124,7 +158,18 @@ fn gradient_with_param() {
         1.6467383807226765,
     );
 
-    let grad = nabla_t(0.0, state, eom);
+    let (fx, grad) = nabla_t(0.0, state, eom);
+
+    let expected_fx = Vector6::new(
+        -3.28878900377057,
+        -2.226285193102822,
+        1.6467383807226765,
+        0.0003488751720191492,
+        -0.0007151349009902908,
+        -0.00027005954128877916,
+    );
+
+    zero_within!((fx - expected_fx).norm(), 1e-16, "f(x) computation is incorrect");
 
     let mut expected = Matrix6::zeros();
 


### PR DESCRIPTION
+ Implemented hyperdual space for partials computation: leads to significantly faster computation, and requires a single call to the function to be derived
+ Extended vector function partial matrices from simply the gradient computation: causes a *breaking change* where the `nabla` functions are renamed `partials` since `nabla` refers specifically to the gradient computation, which is square
+ Changed the `partials` function to return the state and the function derivative: a single call to the function to return the state and its derivative may be useful in applications where such computation is especially heavy
+ Added {Add,Mul,Sub,Div}-Assign from `std::ops` to allow for `+=`, `*=`, `-=` and `/=` operations on duals and their parametrized type, and associated tests

Closes #4 