### PR TITLE
Bump dual_num to 0.2.3 as we are upgrading to nalgebra 0.16.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dual_num"
 description = "Fully-featured Dual Number implementation with features for automatic differentiation of multivariate vectorial functions into gradients"
 authors = ["Aaron Trent <novacrazy@gmail.com>", "Christopher Rabotin <christopher.rabotin@gmail.com>"]
-version = "0.2.2"
+version = "0.2.3"
 license = "MIT"
 include = ["src/**/*", "Cargo.toml"]
 keywords = ["dual", "number", "hyperdual", "gradient", "autodifferentiate"]
@@ -12,4 +12,4 @@ repository = "https://github.com/novacrazy/dual_num"
 
 [dependencies]
 num-traits = "0.2"
-nalgebra = "0.15"
+nalgebra = "0.16"


### PR DESCRIPTION
Note that the purpose of bumping to 0.2.3 is to ensure that other libraries which use 0.2.2 do not need to upgrade nalgebra.

Closes #8 